### PR TITLE
Tweak build.sbt to supress import warnings from Twirl compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val microservice = Project(appName, file("."))
     // ***************
     // Use the silencer plugin to suppress warnings
     // You may turn it on for `views` too to suppress warnings from unused imports in compiled twirl templates, but this will hide other warnings.
-    scalacOptions += "-P:silencer:pathFilters=routes",
+    scalacOptions += "-P:silencer:pathFilters=routes,silencer:pathFilters=twirl",
     libraryDependencies ++= Seq(
       compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
       "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full


### PR DESCRIPTION
@macgrewal Have a look at this - will extend the silencer plugin to prevent the Twirl import warnings at compile time.