### PR TITLE
CIVDT-977: Added the upscan reference to the FileUploadInfo

### DIFF
--- a/app/controllers/FileUploadHandler.scala
+++ b/app/controllers/FileUploadHandler.scala
@@ -99,6 +99,7 @@ trait FileUploadHandler[T] {
       uploadDetails <- doc.uploadDetails
     } yield {
       FileUploadInfo(
+        reference = doc.reference,
         fileName = filename,
         downloadUrl = downloadUrl,
         uploadTimestamp = uploadDetails.uploadTimestamp,

--- a/app/models/FileUploadInfo.scala
+++ b/app/models/FileUploadInfo.scala
@@ -20,12 +20,12 @@ import play.api.libs.json._
 
 import java.time.LocalDateTime
 
-case class FileUploadInfo(fileName: String,
+case class FileUploadInfo(reference: String,
+                          fileName: String,
                           downloadUrl: String,
                           uploadTimestamp: LocalDateTime,
                           checksum: String,
-                          fileMimeType: String
-                         )
+                          fileMimeType: String)
 
 object FileUploadInfo {
   implicit val reads: Reads[FileUploadInfo] = Json.reads[FileUploadInfo]

--- a/test/controllers/RemoveUploadedFileControllerSpec.scala
+++ b/test/controllers/RemoveUploadedFileControllerSpec.scala
@@ -76,6 +76,7 @@ class RemoveUploadedFileControllerSpec extends ControllerSpecBase {
           .set(
             FileUploadPage,
             Seq(FileUploadInfo(
+              reference = "file-ref-1",
               fileName = "file.txt",
               downloadUrl = "url",
               uploadTimestamp = LocalDateTime.now,
@@ -126,6 +127,7 @@ class RemoveUploadedFileControllerSpec extends ControllerSpecBase {
             .set(
               FileUploadPage,
               Seq(FileUploadInfo(
+                reference = "file-ref-1",
                 fileName = "file.txt",
                 downloadUrl = "url",
                 uploadTimestamp = LocalDateTime.now,

--- a/test/controllers/RepresentativeDanImportVATControllerSpec.scala
+++ b/test/controllers/RepresentativeDanImportVATControllerSpec.scala
@@ -195,6 +195,7 @@ class RepresentativeDanImportVATControllerSpec extends ControllerSpecBase {
             UploadAuthority("1234567",
               Duty,
               FileUploadInfo(
+                "file-ref-1",
                 "DutyDocument.pdf",
                 "http://localhost:9570/upscan/download/b1bd66aa-97df-4302-931f-f40a5702a14b",
                 LocalDateTime.of(2020, 1, 10, 10, 31),
@@ -204,6 +205,7 @@ class RepresentativeDanImportVATControllerSpec extends ControllerSpecBase {
             UploadAuthority("7654321",
               Vat,
               FileUploadInfo(
+                "file-ref-1",
                 "VATDocument.pdf",
                 "http://localhost:9570/upscan/download/5e922a0f-d5ad-4aa6-9977-45a83096f71d",
                 LocalDateTime.of(2020, 1, 10, 10, 30),

--- a/test/controllers/SupportingDocControllerSpec.scala
+++ b/test/controllers/SupportingDocControllerSpec.scala
@@ -55,7 +55,7 @@ class SupportingDocControllerSpec extends ControllerSpecBase {
     "redirect to the summary page when uploaded file already exists" in new Test {
       override val userAnswers: Option[UserAnswers] = Some(
         UserAnswers("some-cred-id")
-          .set(FileUploadPage, Seq(FileUploadInfo("test.pdf", "downloadUrl", LocalDateTime.now(), "checksum", "fileMimeType"))).success.value
+          .set(FileUploadPage, Seq(FileUploadInfo("file-ref-1", "test.pdf", "downloadUrl", LocalDateTime.now(), "checksum", "fileMimeType"))).success.value
       )
       val result: Future[Result] = controller.onLoad()(fakeRequest)
       status(result) mustBe Status.SEE_OTHER

--- a/test/controllers/UploadAnotherFileControllerSpec.scala
+++ b/test/controllers/UploadAnotherFileControllerSpec.scala
@@ -37,11 +37,13 @@ class UploadAnotherFileControllerSpec extends ControllerSpecBase {
     private lazy val uploadAnotherFileView: UploadAnotherFileView = app.injector.instanceOf[UploadAnotherFileView]
 
     val data: JsObject = Json.obj("uploaded-files" -> Json.arr(
-      Json.obj("fileName" -> "text.txt",
-      "downloadUrl" -> "http://localhost:9570/upscan/download/6f531dec-108d-4dc9-a586-9a97cf78bc34",
-      "uploadTimestamp" -> "2021-01-26T13:22:59.388",
-      "checksum" -> "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
-      "fileMimeType" -> "application/txt"))
+      Json.obj(
+        "reference" -> "file-ref-1",
+        "fileName" -> "text.txt",
+        "downloadUrl" -> "http://localhost:9570/upscan/download/6f531dec-108d-4dc9-a586-9a97cf78bc34",
+        "uploadTimestamp" -> "2021-01-26T13:22:59.388",
+        "checksum" -> "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+        "fileMimeType" -> "application/txt"))
     )
 
     val userAnswers: Option[UserAnswers] = Some(UserAnswers("credId", data))
@@ -52,7 +54,7 @@ class UploadAnotherFileControllerSpec extends ControllerSpecBase {
     val form: UploadAnotherFileFormProvider = formProvider
 
     lazy val controller = new UploadAnotherFileController(authenticatedAction, dataRetrievalAction, dataRequiredAction,
-       messagesControllerComponents, form, uploadAnotherFileView)
+      messagesControllerComponents, form, uploadAnotherFileView)
   }
 
   "GET onLoad" should {
@@ -78,9 +80,9 @@ class UploadAnotherFileControllerSpec extends ControllerSpecBase {
     "redirect to supporting Doc page when no data present" in new Test {
       override val data: JsObject = Json.obj("" -> "")
       override val userAnswers: Option[UserAnswers] = Some(UserAnswers("some-cred-id", data))
-        val result: Future[Result] = controller.onLoad(fakeRequest)
-        status(result) mustBe Status.SEE_OTHER
-      }
+      val result: Future[Result] = controller.onLoad(fakeRequest)
+      status(result) mustBe Status.SEE_OTHER
+    }
 
   }
 

--- a/test/controllers/UploadAuthorityControllerSpec.scala
+++ b/test/controllers/UploadAuthorityControllerSpec.scala
@@ -292,7 +292,7 @@ class UploadAuthorityControllerSpec extends ControllerSpecBase {
     "return HTML with correct filename" in new Test {
       override val userAnswers: Option[UserAnswers] = Some(UserAnswers("credId")
         .set(SplitPaymentPage, true).success.value
-        .set(UploadAuthorityPage, Seq(UploadAuthority(dan, Duty, FileUploadInfo("filename.txt", "", LocalDateTime.now(), "", "")))).success.value)
+        .set(UploadAuthorityPage, Seq(UploadAuthority(dan, Duty, FileUploadInfo("file-ref-1", "filename.txt", "", LocalDateTime.now(), "", "")))).success.value)
       val result: Future[Result] = controller.onSuccess(Duty, dan)(fakeRequest)
       contentAsString(result).contains("filename.txt") mustBe true
     }
@@ -300,7 +300,7 @@ class UploadAuthorityControllerSpec extends ControllerSpecBase {
     "return HTML with RepresentativeDanImportVAT url when checkMode is false and dutyType is duty" in new Test {
       override val userAnswers: Option[UserAnswers] = Some(UserAnswers("credId")
         .set(SplitPaymentPage, true).success.value
-        .set(UploadAuthorityPage, Seq(UploadAuthority(dan, Duty, FileUploadInfo("", "", LocalDateTime.now(), "", "")))).success.value
+        .set(UploadAuthorityPage, Seq(UploadAuthority(dan, Duty, FileUploadInfo("", "", "", LocalDateTime.now(), "", "")))).success.value
         .set(CheckModePage, false).success.value
         .set(UnderpaymentDetailSummaryPage, Seq(UnderpaymentDetail("B00", 0.0, 1.0), UnderpaymentDetail("A00", 0.0, 1.0))).success.value)
       val result: Future[Result] = controller.onSuccess(Duty, dan)(fakeRequest)
@@ -310,7 +310,7 @@ class UploadAuthorityControllerSpec extends ControllerSpecBase {
     "return HTML with CheckYourAnswers url when checkMode is true" in new Test {
       override val userAnswers: Option[UserAnswers] = Some(UserAnswers("credId")
         .set(SplitPaymentPage, true).success.value
-        .set(UploadAuthorityPage, Seq(UploadAuthority(dan, Duty, FileUploadInfo("filename.txt", "", LocalDateTime.now(), "", "")))).success.value
+        .set(UploadAuthorityPage, Seq(UploadAuthority(dan, Duty, FileUploadInfo("file-ref-1", "filename.txt", "", LocalDateTime.now(), "", "")))).success.value
         .set(CheckModePage, true).success.value
         .set(UnderpaymentDetailSummaryPage, Seq(UnderpaymentDetail("B00", 0.0, 1.0), UnderpaymentDetail("A00", 0.0, 1.0))).success.value)
       val result: Future[Result] = controller.onSuccess(Duty, dan)(fakeRequest)

--- a/test/controllers/UploadFileControllerSpec.scala
+++ b/test/controllers/UploadFileControllerSpec.scala
@@ -125,6 +125,7 @@ class UploadFileControllerSpec extends ControllerSpecBase {
     "return correct back link if come from Summary screen" in new Test {
       override val userAnswers: Option[UserAnswers] = Some(UserAnswers("credId")
         .set(FileUploadPage, Seq(FileUploadInfo(
+          reference = "file-ref-1",
           fileName = "file1",
           downloadUrl = "url",
           uploadTimestamp = LocalDateTime.now(),

--- a/test/services/submissionService/SubmissionServiceTestJson.scala
+++ b/test/services/submissionService/SubmissionServiceTestJson.scala
@@ -110,6 +110,7 @@ trait SubmissionServiceTestJson {
       |   ],
       |   "supportingDocuments":[
       |      {
+      |         "reference":"file-ref-1",
       |         "fileName":"TestDocument.pdf",
       |         "downloadUrl":"http://some/location",
       |         "uploadTimestamp":"2021-05-14T20:15:13.807",
@@ -117,6 +118,7 @@ trait SubmissionServiceTestJson {
       |         "fileMimeType":"application/pdf"
       |      },
       |      {
+      |         "reference":"file-ref-1",
       |         "fileName":"TestDocument.pdf",
       |         "downloadUrl":"http://some/location",
       |         "uploadTimestamp":"2021-05-14T20:15:13.807",
@@ -223,6 +225,7 @@ trait SubmissionServiceTestJson {
       |   ],
       |   "supportingDocuments":[
       |      {
+      |         "reference":"file-ref-1",
       |         "fileName":"TestDocument.pdf",
       |         "downloadUrl":"http://some/location",
       |         "uploadTimestamp":"2021-05-14T20:15:13.807",
@@ -242,6 +245,7 @@ trait SubmissionServiceTestJson {
       |   ],
       |   "supportingDocuments":[
       |      {
+      |         "reference":"file-ref-1",
       |         "fileName":"TestDocument.pdf",
       |         "downloadUrl":"http://some/location",
       |         "uploadTimestamp":"2021-05-14T20:15:13.807",
@@ -249,6 +253,7 @@ trait SubmissionServiceTestJson {
       |         "fileMimeType":"application/pdf"
       |      },
       |      {
+      |         "reference":"file-ref-1",
       |         "fileName":"TestDocument.pdf",
       |         "downloadUrl":"http://some/location",
       |         "uploadTimestamp":"2021-05-14T20:15:13.807",
@@ -272,6 +277,7 @@ trait SubmissionServiceTestJson {
       |   ],
       |   "supportingDocuments":[
       |      {
+      |         "reference":"file-ref-1",
       |         "fileName":"TestDocument.pdf",
       |         "downloadUrl":"http://some/location",
       |         "uploadTimestamp":"2021-05-14T20:15:13.807",
@@ -279,6 +285,7 @@ trait SubmissionServiceTestJson {
       |         "fileMimeType":"application/pdf"
       |      },
       |      {
+      |         "reference":"file-ref-1",
       |         "fileName":"TestDocument.pdf",
       |         "downloadUrl":"http://some/location",
       |         "uploadTimestamp":"2021-05-14T20:15:13.807",
@@ -302,6 +309,7 @@ trait SubmissionServiceTestJson {
       |   ],
       |   "supportingDocuments":[
       |      {
+      |         "reference":"file-ref-1",
       |         "fileName":"TestDocument.pdf",
       |         "downloadUrl":"http://some/location",
       |         "uploadTimestamp":"2021-05-14T20:15:13.807",
@@ -309,6 +317,7 @@ trait SubmissionServiceTestJson {
       |         "fileMimeType":"application/pdf"
       |      },
       |      {
+      |         "reference":"file-ref-1",
       |         "fileName":"TestDocument.pdf",
       |         "downloadUrl":"http://some/location",
       |         "uploadTimestamp":"2021-05-14T20:15:13.807",

--- a/test/utils/ReusableValues.scala
+++ b/test/utils/ReusableValues.scala
@@ -115,6 +115,7 @@ trait ReusableValues {
   val cpc: String = "4000C09"
   val supportingDocuments: Seq[FileUploadInfo] = Seq(
     FileUploadInfo(
+      reference = "file-ref-1",
       fileName = "TestDocument.pdf",
       downloadUrl = "http://some/location",
       uploadTimestamp = validTimestamp,
@@ -127,6 +128,7 @@ trait ReusableValues {
       defermentAccountNumber,
       SelectedDutyTypes.Duty,
       FileUploadInfo(
+        reference = "file-ref-1",
         fileName = "TestDocument.pdf",
         downloadUrl = "http://some/location",
         uploadTimestamp = validTimestamp,
@@ -139,6 +141,7 @@ trait ReusableValues {
       defermentAccountNumber,
       SelectedDutyTypes.Vat,
       FileUploadInfo(
+        reference = "file-ref-1",
         fileName = "TestDocument.pdf",
         downloadUrl = "http://some/location",
         uploadTimestamp = validTimestamp,

--- a/test/viewmodels/AddFileRowHelperSpec.scala
+++ b/test/viewmodels/AddFileRowHelperSpec.scala
@@ -17,9 +17,9 @@
 package viewmodels
 
 import base.SpecBase
-import models.{FileUploadInfo, UserAnswers}
+import models.FileUploadInfo
 import org.scalatest.{MustMatchers, OptionValues, TryValues}
-import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.json.{JsValue, Json}
 import play.twirl.api.Html
 
 class AddFileRowHelperSpec extends SpecBase with MustMatchers with TryValues with OptionValues {
@@ -35,21 +35,15 @@ class AddFileRowHelperSpec extends SpecBase with MustMatchers with TryValues wit
 
     "must contain one item per file" in {
       def fileUploadInfo(filename: String): JsValue = {
-        Json.obj("fileName" -> s"${filename}",
+        Json.obj(
+          "reference" -> "file-ref-1",
+          "fileName" -> filename,
           "downloadUrl" -> "http://localhost:9570/upscan/download/6f531dec-108d-4dc9-a586-9a97cf78bc34",
           "uploadTimestamp" -> "2021-01-26T13:22:59.388",
           "checksum" -> "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
           "fileMimeType" -> "application/txt")
       }
 
-      val data: JsObject = Json.obj("uploaded-files" -> Json.arr(
-        fileUploadInfo("text.txt"),
-        fileUploadInfo("text2.txt"),
-        fileUploadInfo("text3.txt")
-      ))
-
-      val answers =
-        UserAnswers("id", data)
       val helper = new AddFileNameRowHelper(
         Seq(
           Json.fromJson[FileUploadInfo](fileUploadInfo("text.txt")).get,

--- a/test/viewmodels/cya/CYAPaymentSummaryListHelperSpec.scala
+++ b/test/viewmodels/cya/CYAPaymentSummaryListHelperSpec.scala
@@ -36,6 +36,7 @@ class CYAPaymentSummaryListHelperSpec extends SpecBase with MustMatchers with Tr
       .set(EntryDetailsPage, EntryDetails("123", "123456Q", LocalDate.of(2020, 12, 1))).success.value
       .set(AcceptanceDatePage, true).success.value
       .set(FileUploadPage, Seq(FileUploadInfo(
+        "file-ref-1",
         "Example.pdf",
         "https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
         LocalDateTime.now,
@@ -70,6 +71,7 @@ class CYAPaymentSummaryListHelperSpec extends SpecBase with MustMatchers with Tr
           "1284958",
           SelectedDutyTypes.Duty,
           FileUploadInfo(
+            "file-ref-1",
             "DutyFileExample.pdf",
             "https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
             LocalDateTime.now,
@@ -79,6 +81,7 @@ class CYAPaymentSummaryListHelperSpec extends SpecBase with MustMatchers with Tr
           "5293747",
           SelectedDutyTypes.Vat,
           FileUploadInfo(
+            "file-ref-1",
             "VATFileExample.pdf",
             "https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
             LocalDateTime.now,
@@ -153,6 +156,7 @@ class CYAPaymentSummaryListHelperSpec extends SpecBase with MustMatchers with Tr
           .set(EntryDetailsPage, EntryDetails("123", "123456Q", LocalDate.of(2020, 12, 1))).success.value
           .set(AcceptanceDatePage, true).success.value
           .set(FileUploadPage, Seq(FileUploadInfo(
+            "file-ref-1",
             "Example.pdf",
             "https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
             LocalDateTime.now,
@@ -203,6 +207,7 @@ class CYAPaymentSummaryListHelperSpec extends SpecBase with MustMatchers with Tr
           .set(EntryDetailsPage, EntryDetails("123", "123456Q", LocalDate.of(2020, 12, 1))).success.value
           .set(AcceptanceDatePage, true).success.value
           .set(FileUploadPage, Seq(FileUploadInfo(
+            "file-ref-1",
             "Example.pdf",
             "https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
             LocalDateTime.now,
@@ -253,6 +258,7 @@ class CYAPaymentSummaryListHelperSpec extends SpecBase with MustMatchers with Tr
           .set(EntryDetailsPage, EntryDetails("123", "123456Q", LocalDate.of(2020, 12, 1))).success.value
           .set(AcceptanceDatePage, true).success.value
           .set(FileUploadPage, Seq(FileUploadInfo(
+            "file-ref-1",
             "Example.pdf",
             "https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
             LocalDateTime.now,
@@ -286,6 +292,7 @@ class CYAPaymentSummaryListHelperSpec extends SpecBase with MustMatchers with Tr
               "1284958",
               SelectedDutyTypes.Duty,
               FileUploadInfo(
+                "file-ref-1",
                 "DutyFileExample.pdf",
                 "https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
                 LocalDateTime.now,
@@ -316,6 +323,7 @@ class CYAPaymentSummaryListHelperSpec extends SpecBase with MustMatchers with Tr
           .set(EntryDetailsPage, EntryDetails("123", "123456Q", LocalDate.of(2020, 12, 1))).success.value
           .set(AcceptanceDatePage, true).success.value
           .set(FileUploadPage, Seq(FileUploadInfo(
+            "file-ref-1",
             "Example.pdf",
             "https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
             LocalDateTime.now,
@@ -350,6 +358,7 @@ class CYAPaymentSummaryListHelperSpec extends SpecBase with MustMatchers with Tr
               "1284958",
               SelectedDutyTypes.Both,
               FileUploadInfo(
+                "file-ref-1",
                 "FileExample.pdf",
                 "https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
                 LocalDateTime.now,
@@ -398,6 +407,7 @@ class CYAPaymentSummaryListHelperSpec extends SpecBase with MustMatchers with Tr
           .set(EntryDetailsPage, EntryDetails("123", "123456Q", LocalDate.of(2020, 12, 1))).success.value
           .set(AcceptanceDatePage, true).success.value
           .set(FileUploadPage, Seq(FileUploadInfo(
+            "file-ref-1",
             "Example.pdf",
             "https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
             LocalDateTime.now,

--- a/test/viewmodels/cya/CYASummaryListHelperSpec.scala
+++ b/test/viewmodels/cya/CYASummaryListHelperSpec.scala
@@ -37,6 +37,7 @@ class CYASummaryListHelperSpec extends SpecBase with MustMatchers with TryValues
       .set(EntryDetailsPage, EntryDetails("123", "123456Q", LocalDate.of(2020, 12, 1))).success.value
       .set(AcceptanceDatePage, true).success.value
       .set(FileUploadPage, Seq(FileUploadInfo(
+        "file-ref-1",
         "Example.pdf",
         "https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
         LocalDateTime.now,


### PR DESCRIPTION
The `upscan` reference is needed when transmitting supporting documentation.