### PR TITLE
CIVDT-1065: Remove unintended implicit conversions

### DIFF
--- a/app/controllers/UploadAuthorityController.scala
+++ b/app/controllers/UploadAuthorityController.scala
@@ -81,7 +81,7 @@ class UploadAuthorityController @Inject()(identify: IdentifierAction,
       case _ => formProvider()
     }
 
-    upScanService.initiateAuthorityJourney(dutyType, dan).map { response =>
+    upScanService.initiateAuthorityJourney(dutyType.toString, dan).map { response =>
       Ok(view(form, response, backLink(dutyType, dan, request.dutyType, splitPayment), dan, dutyTypeKey))
         .removingFromSession("AuthorityUpscanReference")
         .addingToSession("AuthorityUpscanReference" -> response.reference.value)

--- a/app/models/package.scala
+++ b/app/models/package.scala
@@ -19,7 +19,7 @@ import scala.language.implicitConversions
 
 package object models {
 
-  implicit def withNameToString[A >: WithName](x: A): String = x.toString
+  implicit def withNameToString[A <: WithName](x: A): String = x.toString
 
   implicit class RichJsObject(jsObject: JsObject) {
 

--- a/app/services/SubmissionService.scala
+++ b/app/services/SubmissionService.scala
@@ -75,7 +75,7 @@ class SubmissionService @Inject()(ivdSubmissionConnector: IvdSubmissionConnector
         }
       case JsError(err) => {
         logger.error(s"Invalid User Answers data. Failed to parse into SubmissionData model. Error: ${err}")
-        Left(ErrorModel(-1, err))
+        Left(ErrorModel(-1, err.toString()))
       }
     }
   }

--- a/app/views/BulkUploadFileView.scala.html
+++ b/app/views/BulkUploadFileView.scala.html
@@ -84,8 +84,8 @@
                 isPageHeading = false,
                 attributes = Map(
                     "accept" -> appConfig.upScanAcceptedFileTypes,
-                    "data-max-file-size" -> appConfig.upScanMaxFileSize,
-                    "data-min-file-size" -> appConfig.upScanMinFileSize
+                    "data-max-file-size" -> appConfig.upScanMaxFileSize.toString,
+                    "data-min-file-size" -> appConfig.upScanMinFileSize.toString
                 )
             )
 

--- a/app/views/CurrencyAmendmentView.scala.html
+++ b/app/views/CurrencyAmendmentView.scala.html
@@ -34,10 +34,10 @@
     @h1(messages(s"box${boxNumber}.pageHeader", itemNumber))
 
     @formHelper(action = formAction) {
-        @currencyInput(form, "original", messages("amendmentValue.originalAmount"), 10, false,
-            classes = inputClass)
-        @currencyInput(form, "amended", messages("amendmentValue.amendedAmount"), 10, false,
-            classes = inputClass)
+        @currencyInput(form, "original", messages("amendmentValue.originalAmount"), "10", false,
+            classes = inputClass.getOrElse(""))
+        @currencyInput(form, "amended", messages("amendmentValue.amendedAmount"), "10", false,
+            classes = inputClass.getOrElse(""))
         @button("common.button.continue")
     }
 }

--- a/app/views/GuidanceView.scala.html
+++ b/app/views/GuidanceView.scala.html
@@ -39,11 +39,11 @@
     @h2("Contents", Some("0"))
 
     @bullets(Seq(
-        Html(<a class="gem-c-contents-list__link govuk-link " data-track-category="contentsClicked" data-track-action="content_item 1" data-track-label="#who-should-claim" data-track-options="{&quot;dimension29&quot;:&quot;Who should claim&quot;}" href="#1">Who can use this service</a>),
-        Html(<a class="gem-c-contents-list__link govuk-link " data-track-category="contentsClicked" data-track-action="content_item 1" data-track-label="#who-should-claim" data-track-options="{&quot;dimension29&quot;:&quot;Who should claim&quot;}" href="#2">Before you start</a>),
-        Html(<a class="gem-c-contents-list__link govuk-link " data-track-category="contentsClicked" data-track-action="content_item 1" data-track-label="#who-should-claim" data-track-options="{&quot;dimension29&quot;:&quot;Who should claim&quot;}" href="#3">What you’ll need</a>),
-        Html(<a class="gem-c-contents-list__link govuk-link " data-track-category="contentsClicked" data-track-action="content_item 1" data-track-label="#who-should-claim" data-track-options="{&quot;dimension29&quot;:&quot;Who should claim&quot;}" href="#4">How to disclose</a>),
-        Html(<a class="gem-c-contents-list__link govuk-link " data-track-category="contentsClicked" data-track-action="content_item 1" data-track-label="#who-should-claim" data-track-options="{&quot;dimension29&quot;:&quot;Who should claim&quot;}" href="#5">After you've disclosed</a>)
+        Html(<a class="gem-c-contents-list__link govuk-link " data-track-category="contentsClicked" data-track-action="content_item 1" data-track-label="#who-should-claim" data-track-options="{&quot;dimension29&quot;:&quot;Who should claim&quot;}" href="#1">Who can use this service</a>.toString),
+        Html(<a class="gem-c-contents-list__link govuk-link " data-track-category="contentsClicked" data-track-action="content_item 1" data-track-label="#who-should-claim" data-track-options="{&quot;dimension29&quot;:&quot;Who should claim&quot;}" href="#2">Before you start</a>.toString),
+        Html(<a class="gem-c-contents-list__link govuk-link " data-track-category="contentsClicked" data-track-action="content_item 1" data-track-label="#who-should-claim" data-track-options="{&quot;dimension29&quot;:&quot;Who should claim&quot;}" href="#3">What you’ll need</a>.toString),
+        Html(<a class="gem-c-contents-list__link govuk-link " data-track-category="contentsClicked" data-track-action="content_item 1" data-track-label="#who-should-claim" data-track-options="{&quot;dimension29&quot;:&quot;Who should claim&quot;}" href="#4">How to disclose</a>.toString),
+        Html(<a class="gem-c-contents-list__link govuk-link " data-track-category="contentsClicked" data-track-action="content_item 1" data-track-label="#who-should-claim" data-track-options="{&quot;dimension29&quot;:&quot;Who should claim&quot;}" href="#5">After you've disclosed</a>.toString)
     ))
 
 

--- a/app/views/ImporterConfirmationView.scala.html
+++ b/app/views/ImporterConfirmationView.scala.html
@@ -69,7 +69,7 @@
 
     <div id="helpImproveServiceLink">
         @p{
-            @Html(<a href={appConfig.surveyUrl} class="govuk-link">{messages("confirmation.helpImproveServiceLink")}</a>)
+            <a href={appConfig.surveyUrl} class="govuk-link">@{messages("confirmation.helpImproveServiceLink")}</a>
             @Html(messages("confirmation.helpImproveServiceLinkTime"))
         }
     </div>

--- a/app/views/RepresentativeConfirmationView.scala.html
+++ b/app/views/RepresentativeConfirmationView.scala.html
@@ -67,11 +67,11 @@
 
     @p(Html(messages("confirmation.whatYouShouldDoNext.p5")))
 
-    @p{@Html(<a href={controllers.routes.IndexController.onPageLoad.url} id="discloseAnotherUnderpayment" class="govuk-link">{messages("confirmation.whatYouShouldDoNext.rep.link")}</a>)}
+    @p{<a href={controllers.routes.IndexController.onPageLoad.url} id="discloseAnotherUnderpayment" class="govuk-link">@{messages("confirmation.whatYouShouldDoNext.rep.link")}</a>}
 
     <div id="helpImproveServiceLink">
         @p{
-            @Html(<a href={appConfig.surveyUrl} class="govuk-link">{messages("confirmation.helpImproveServiceLink")}</a>)
+            <a href={appConfig.surveyUrl} class="govuk-link">@{messages("confirmation.helpImproveServiceLink")}</a>
             @Html(messages("confirmation.helpImproveServiceLinkTime"))
         }
     </div>

--- a/app/views/UnderpaymentReasonSummaryView.scala.html
+++ b/app/views/UnderpaymentReasonSummaryView.scala.html
@@ -37,13 +37,13 @@
 
 @layout(
     form = Some(form),
-    pageTitle = titleAndHeader,
+    pageTitle = titleAndHeader.toString,
     showBackLink = false
 ) {
 
     @errorSummary(form.errors)
 
-    @h1(titleAndHeader)
+    @h1(titleAndHeader.toString)
 
     @if(summaryList.isDefined) {
         @govukSummaryList(summaryList.get)

--- a/app/views/UploadAuthorityView.scala.html
+++ b/app/views/UploadAuthorityView.scala.html
@@ -82,8 +82,8 @@
             isPageHeading = false,
             attributes = Map(
                 "accept" -> appConfig.upScanAcceptedFileTypes,
-                "data-max-file-size" -> appConfig.upScanMaxFileSize,
-                "data-min-file-size" -> appConfig.upScanMinFileSize
+                "data-max-file-size" -> appConfig.upScanMaxFileSize.toString,
+                "data-min-file-size" -> appConfig.upScanMinFileSize.toString
             )
         )
        </div>

--- a/app/views/UploadFileView.scala.html
+++ b/app/views/UploadFileView.scala.html
@@ -94,8 +94,8 @@
                 isPageHeading = false,
                 attributes = Map(
                     "accept" -> appConfig.upScanAcceptedFileTypes,
-                    "data-max-file-size" -> appConfig.upScanMaxFileSize,
-                    "data-min-file-size" -> appConfig.upScanMinFileSize
+                    "data-max-file-size" -> appConfig.upScanMaxFileSize.toString,
+                    "data-min-file-size" -> appConfig.upScanMinFileSize.toString
                 )
             )
        </div>

--- a/app/views/components/back_link.scala.html
+++ b/app/views/components/back_link.scala.html
@@ -20,7 +20,7 @@
 
 @(url: Option[Call] = None)(implicit messages: Messages)
 
-@govukBackLink(BackLink(href = url.map(_.toString).getOrElse("#"), content = Text(messages("common.back")), attributes = Map("id" -> "back-link")))
+@govukBackLink(BackLink(href = url.map(_.url).getOrElse("#"), content = Text(messages("common.back")), attributes = Map("id" -> "back-link")))
 
 @{
  //$COVERAGE-OFF$

--- a/app/views/components/back_link.scala.html
+++ b/app/views/components/back_link.scala.html
@@ -20,7 +20,7 @@
 
 @(url: Option[Call] = None)(implicit messages: Messages)
 
-@govukBackLink(BackLink(href = url.fold("#")(customUrl => customUrl), content = Text(messages("common.back")), attributes = Map("id" -> "back-link")))
+@govukBackLink(BackLink(href = url.map(_.toString).getOrElse("#"), content = Text(messages("common.back")), attributes = Map("id" -> "back-link")))
 
 @{
  //$COVERAGE-OFF$

--- a/app/views/components/inputDate.scala.html
+++ b/app/views/components/inputDate.scala.html
@@ -71,7 +71,7 @@
 }
 
 @componentHasError(subId: String) = @{
-    form.errors.map(err => !err.args.filter(arg => arg.contains(subId)).isEmpty).filter(_.equals(true)).headOption.getOrElse(false)
+    form.errors.map(err => !err.args.filter(arg => arg.toString.contains(subId)).isEmpty).filter(_.equals(true)).headOption.getOrElse(false)
 }
 
 @{

--- a/app/views/errors/UnauthorisedView.scala.html
+++ b/app/views/errors/UnauthorisedView.scala.html
@@ -20,7 +20,7 @@
 
 @()(implicit request: Request[_], messages: Messages)
 
-@layout(pageTitle = Some("import-voluntary-disclosure-frontend")) {
+@layout(pageTitle = "import-voluntary-disclosure-frontend") {
     <h1 class="govuk-heading-xl">Unauthorised</h1>
 }
 

--- a/app/views/underpayments/ChangeUnderpaymentDetailsView.scala.html
+++ b/app/views/underpayments/ChangeUnderpaymentDetailsView.scala.html
@@ -39,8 +39,8 @@
     }
 
     @formHelper(action = controllers.underpayments.routes.ChangeUnderpaymentDetailsController.onSubmit(underpaymentType)) {
-        @currencyInput(form, "original", messages("changeUnderpaymentDetails.originalAmount"), 10, false, classes = "govuk-input--width-20")
-        @currencyInput(form, "amended", messages("changeUnderpaymentDetails.amendedAmount"), 10, false, classes = "govuk-input--width-20")
+        @currencyInput(form, "original", messages("changeUnderpaymentDetails.originalAmount"), "10", false, classes = "govuk-input--width-20")
+        @currencyInput(form, "amended", messages("changeUnderpaymentDetails.amendedAmount"), "10", false, classes = "govuk-input--width-20")
         @if(summaryPageChange) {
         <p><a href=@controllers.underpayments.routes.RemoveUnderpaymentDetailsController.onLoad(underpaymentType).url id="remove-link" class="govuk-link">@messages(s"changeUnderpaymentDetails.$underpaymentType.removeLink")</a></p>
         }

--- a/app/views/underpayments/UnderpaymentDetailsView.scala.html
+++ b/app/views/underpayments/UnderpaymentDetailsView.scala.html
@@ -39,8 +39,8 @@
         }
 
     @formHelper(action = controllers.underpayments.routes.UnderpaymentDetailsController.onSubmit(underpaymentType)) {
-        @currencyInput(form, "original", messages("underpaymentDetails.originalAmount"), 10, false, classes = "govuk-input--width-20")
-        @currencyInput(form, "amended", messages("underpaymentDetails.amendedAmount"), 10, false, classes = "govuk-input--width-20")
+        @currencyInput(form, "original", messages("underpaymentDetails.originalAmount"), "10", false, classes = "govuk-input--width-20")
+        @currencyInput(form, "amended", messages("underpaymentDetails.amendedAmount"), "10", false, classes = "govuk-input--width-20")
         @button("common.button.continue")
     }
 }


### PR DESCRIPTION
This line:
```scala
implicit def withNameToString[A >: WithName](x: A): String = x.toString
```
introduces an implicit conversion for all supertypes of `WithType` (which are `AnyRef` and `Any`) and this has lead people to accidentally convert values to String in many places in the code (some strange conversions from Option, Int etc have lead to subtle bugs).

I think what was intended was this:
```scala
implicit def withNameToString[A <: WithName](x: A): String = x.toString
```
which introduces a conversion only for subtypes of WithName (like Enums in this project for example).

In this PR I've changed the conversion to apply to subtypes and replaced all the unintended conversions with explicit conversions

The reason I'm doing this is that the implicit conversion to String leads to implicit resolution issues in Play 2.8 so it needs to be fixed before upgrading.
